### PR TITLE
[pom] Skip formatters during release cycle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -904,6 +904,33 @@ limitations under the License.
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>com.github.ekryd.sortpom</groupId>
+            <artifactId>sortpom-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>net.revelc.code.formatter</groupId>
+            <artifactId>formatter-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          <plugin>
+            <groupId>com.mycila</groupId>
+            <artifactId>license-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>net.revelc.code</groupId>
+            <artifactId>impsort-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
Fixes #10 

The issue faced in #10 happens during maven release profile.  So it seems the appropriate fix would be to skip any formatters during that cycle as they should not be adding anything during that process.  The two specific ones that were problematic were sortpom and formatter.  However, there is little need to have the others doing anything during that cycle.  Line endings otherwise can remain LF.
